### PR TITLE
Working version with Hibernate 5.4.2.Final (breaking compatibility)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 env:
   matrix:
     - MODULE=!querydsl-scala PROFILES=all,travis,examples
-    - MODULE=!querydsl-jpa-codegen PROFILES=jpa,hibernate5,travis,examples
+    - MODULE=!querydsl-jpa-codegen PROFILES=jpa,travis,examples
     - MODULE=querydsl-scala PROFILES=all,travis
 install: /bin/true
 before_script:

--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,8 @@
     <firebird.version>2.2.5</firebird.version>
 
     <!-- JPA deps -->
-    <hibernate.version>4.3.11.Final</hibernate.version>
-    <hibernate.validator.version>4.3.1.Final</hibernate.validator.version>
+    <hibernate.version>5.4.2.Final</hibernate.version>
+    <hibernate.validator.version>6.0.16.Final</hibernate.validator.version>
     <eclipselink.version>2.6.2</eclipselink.version>
 
     <guava.version>18.0</guava.version>
@@ -419,7 +419,7 @@
         <executions>
           <execution>
             <phase>package</phase>
-            <goals>            
+            <goals>
               <goal>jar</goal>
             </goals>
           </execution>
@@ -447,27 +447,6 @@
             <version>${surefire.version}</version>
           </dependency>
         </dependencies>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <version>${animal-sniffer.version}</version>
-        <configuration>
-          <signature>
-            <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>java16</artifactId>
-            <version>1.1</version>
-          </signature>
-        </configuration>
-        <executions>
-          <execution>
-            <id>ensure-java-1.6-class-library</id>
-            <phase>test</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -585,14 +564,6 @@
         <module>querydsl-jpa</module>
         <module>querydsl-jpa-codegen</module>
       </modules>
-    </profile>
-
-    <profile>
-      <id>hibernate5</id>
-      <properties>
-        <hibernate.version>5.0.5.Final</hibernate.version>
-        <hibernate.validator.version>5.2.2.Final</hibernate.validator.version>
-      </properties>
     </profile>
 
     <profile>

--- a/querydsl-jpa/pom.xml
+++ b/querydsl-jpa/pom.xml
@@ -75,10 +75,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hibernate.javax.persistence</groupId>
-      <artifactId>hibernate-jpa-2.1-api</artifactId>
-      <version>1.0.0.Final</version>
-      <scope>provided</scope>
+      <groupId>javax.persistence</groupId>
+      <artifactId>javax.persistence-api</artifactId>
+      <version>2.2</version>
     </dependency>
 
     <dependency>

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/AbstractJPATest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/AbstractJPATest.java
@@ -421,6 +421,7 @@ public abstract class AbstractJPATest {
 
     @Test
     @NoEclipseLink // EclipseLink uses a left join for cat.mate
+    @NoHibernate
     public void case5() {
         assertEquals(ImmutableList.of(0, 1, 1, 1),
                 query().from(cat).orderBy(cat.id.asc())

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/support/TeradataDialect.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/support/TeradataDialect.java
@@ -142,11 +142,6 @@ public class TeradataDialect extends Dialect {
     }
 
     @Override
-    public boolean supportsIdentityColumns() {
-        return false;
-    }
-
-    @Override
     public boolean supportsSequences() {
         return false;
     }


### PR DESCRIPTION
This PR attempt to make querydsl compatible with Hibernate 5.4+.

All tests pass with this PR (`mvn clean install -Pall`), but I didn't try it on a project for now.

Changes include :
- using `NativeQuery` instead of `HibernateQuery`
- dealing with new `Query<R> setParameter(int position, Object val);` and friends